### PR TITLE
add install method for consistency

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var dargs = require('dargs')
 var noop = function () {}
 
 module.exports = command.bind(null, 'install')
+module.exports.install = command.bind(null, 'install')
 module.exports.uninstall = command.bind(null, 'uninstall')
 
 function command (cmd, packages, opt, cb) {


### PR DESCRIPTION
This is **MINOR**: exporting `install` as a method makes the API more symmetrical and easier to read internally if `install` or `spawn` were the var used to import the module.  
