### PR TITLE
Added shell option

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ function command (cmd, packages, opt, cb) {
   }
 
   var spawnArgs = {
+    shell: true,
     cwd: opt.cwd,
     env: opt.env || process.env,
     stdio: opt.stdio


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high

Implementation of this comment which prevents execution of shell scripts now (and prevented me to install an npm package on my local computer). Related to https://github.com/mattdesl/canvas-sketch/issues/199.